### PR TITLE
feat: [ORI-1881] Add development environment and URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
-# Submit a pull request
+## Why
 
-## Description of the pull request
+### How
+
+### How Has This Been Tested?
+
+### Checklist

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# Official Python sdk for [Original](https://getoriginal.com) API
+# Official Python SDK for [Original](https://getoriginal.com) API
 
 ## Table of Contents
 
-- [About Original](#-about-original)
 - [Getting Started](#-getting-started)
 - [Documentation](#-documentation)
   - [Initialization](#initialization)
@@ -13,11 +12,11 @@
   - [Burn](#burn)
   - [Deposit](#deposit)
 
-## 📝 About Original
-
-You can request access for an Original account at our [Request Access](https://getoriginal.com/contact-us/) page.
 
 ## ✨ Getting started
+
+Ensure you have registered for an account at [Original](https://app.getoriginal.com) before getting started.
+You will need to create an app and note down your API key and secret from the [API Keys page](https://docs.getoriginal.com/docs/create-your-api-key) to use the Original SDK.
 
 Install Original
 
@@ -33,17 +32,35 @@ The Original SDK is set up to expose the Original API.
 
 Read the full [Original API documentation](https://docs.getoriginal.com).
 
-```python
 
+Create a new instance of the Original client by passing in your api key and secret, with the environment associated with that app.
+
+### Development
+For development apps, you must pass the environment:
+
+```python
+from original_sdk import OriginalClient, Environment
+
+client = OriginalClient(api_key='YOUR_DEV_APP_API_KEY', api_secret='YOUR_DEV_APP_SECRET', env=Environment.Development)
+```
+
+### Production
+For production apps, you can optionally pass the production environment:
+
+```python
+from original_sdk import OriginalClient, Environment
+
+client = OriginalClient(api_key='YOUR_PROD_APP_API_KEY', api_secret='YOUR_PROD_APP_SECRET', env=Environment.Production)
+```
+
+or omit the environment, which will default to production:
+
+```python
 from original_sdk import OriginalClient
 
+client = OriginalClient(api_key='YOUR_PROD_APP_API_KEY', api_secret='YOUR_PROD_APP_SECRET')
 ```
 
-Create a new instance of the Original client by passing in your api key and api key secret.
-
-```python
-client = OriginalClient(api_key='YOUR_API_KEY', api_secret='API_KEY_SECRET')
-```
 
 ### User
 

--- a/original_sdk/__init__.py
+++ b/original_sdk/__init__.py
@@ -1,4 +1,5 @@
 from .async_client import OriginalAsyncClient
 from .client import OriginalClient
+from .types.environment import Environment
 
-__all__ = ["OriginalClient", "OriginalAsyncClient"]
+__all__ = ["OriginalClient", "OriginalAsyncClient", "Environment"]

--- a/original_sdk/base/client.py
+++ b/original_sdk/base/client.py
@@ -25,6 +25,7 @@ class BaseOriginalClient(abc.ABC):
 
         self.options = options
         self.base_url = PRODUCTION_BASE_URL
+        self.env = None
         self.api_version = DEFAULT_API_VERSION
 
         if options.get("base_url"):
@@ -32,13 +33,15 @@ class BaseOriginalClient(abc.ABC):
         elif os.getenv("ORIGINAL_URL"):
             self.base_url = os.environ["ORIGINAL_URL"]
 
-        env = options.get("env")
-        if env:
-            env = get_environment(env)
-            if env == Environment.Development:
-                self.base_url = DEVELOPMENT_BASE_URL
-            elif env == Environment.Production:
-                self.base_url = PRODUCTION_BASE_URL
+        if options.get("env"):
+            self.env = get_environment(options.get("env"))
+        elif os.getenv("ORIGINAL_ENV"):
+            self.env = get_environment(os.environ["ORIGINAL_ENV"])
+
+        if self.env == Environment.Development:
+            self.base_url = DEVELOPMENT_BASE_URL
+        elif self.env == Environment.Production:
+            self.base_url = PRODUCTION_BASE_URL
 
         if options.get("api_version"):
             self.api_version = options["api_version"]

--- a/original_sdk/base/client.py
+++ b/original_sdk/base/client.py
@@ -34,7 +34,7 @@ class BaseOriginalClient(abc.ABC):
             self.base_url = os.environ["ORIGINAL_URL"]
 
         if options.get("env"):
-            self.env = get_environment(options.get("env"))
+            self.env = get_environment(options["env"])
         elif os.getenv("ORIGINAL_ENV"):
             self.env = get_environment(os.environ["ORIGINAL_ENV"])
 

--- a/original_sdk/base/client.py
+++ b/original_sdk/base/client.py
@@ -4,9 +4,11 @@ from typing import Any, Awaitable, Dict, Union
 
 import jwt
 
+from original_sdk.types.environment import Environment, get_environment
 from original_sdk.types.original_response import OriginalResponse
 
-DEFAULT_BASE_URL = "https://api.getoriginal.com"
+DEVELOPMENT_BASE_URL = "https://api-dev.getoriginal.com"
+PRODUCTION_BASE_URL = "https://api.getoriginal.com"
 DEFAULT_API_VERSION = "v1"
 
 
@@ -22,13 +24,21 @@ class BaseOriginalClient(abc.ABC):
             self.timeout = float(os.environ["ORIGINAL_TIMEOUT"])
 
         self.options = options
-        self.base_url = DEFAULT_BASE_URL
+        self.base_url = PRODUCTION_BASE_URL
         self.api_version = DEFAULT_API_VERSION
 
         if options.get("base_url"):
             self.base_url = options["base_url"]
         elif os.getenv("ORIGINAL_URL"):
             self.base_url = os.environ["ORIGINAL_URL"]
+
+        env = options.get("env")
+        if env:
+            env = get_environment(env)
+            if env == Environment.Development:
+                self.base_url = DEVELOPMENT_BASE_URL
+            elif env == Environment.Production:
+                self.base_url = PRODUCTION_BASE_URL
 
         if options.get("api_version"):
             self.api_version = options["api_version"]

--- a/original_sdk/tests/test_client.py
+++ b/original_sdk/tests/test_client.py
@@ -1,9 +1,10 @@
 import os
 
 import jwt
+import pytest
 from dotenv import load_dotenv
 
-from original_sdk import OriginalClient
+from original_sdk import OriginalClient, Environment
 
 load_dotenv()
 
@@ -24,7 +25,7 @@ class TestClient:
             "api_secret": TEST_API_SECRET,
         }
 
-    def test_default_base_url(self):
+    def test_default_base_url_is_production(self):
         client = OriginalClient(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
         assert client.base_url == "https://api.getoriginal.com"
 
@@ -55,3 +56,44 @@ class TestClient:
             api_version="v2",
         )
         assert client.api_version == "v2"
+
+    def test_development_url_is_set_from_enum(self):
+        client = OriginalClient(
+            api_key=TEST_API_KEY,
+            api_secret=TEST_API_SECRET,
+            env=Environment.Development,
+        )
+        assert client.base_url == "https://api-dev.getoriginal.com"
+
+    def test_development_url_is_set_from_string(self):
+        client = OriginalClient(
+            api_key=TEST_API_KEY,
+            api_secret=TEST_API_SECRET,
+            env="development",
+        )
+        assert client.base_url == "https://api-dev.getoriginal.com"
+
+    def test_production_url_is_set_from_enum(self):
+        client = OriginalClient(
+            api_key=TEST_API_KEY,
+            api_secret=TEST_API_SECRET,
+            env=Environment.Production,
+        )
+        assert client.base_url == "https://api.getoriginal.com"
+
+    def test_production_url_is_set_from_string(self):
+        client = OriginalClient(
+            api_key=TEST_API_KEY,
+            api_secret=TEST_API_SECRET,
+            env="production",
+        )
+        assert client.base_url == "https://api.getoriginal.com"
+
+    def test_url_raises_error_if_bad_env_is_passed(self):
+        with pytest.raises(ValueError) as ex:
+            OriginalClient(
+                api_key=TEST_API_KEY,
+                api_secret=TEST_API_SECRET,
+                env="bad_env",
+            )
+        assert "Invalid environment" in str(ex.value)

--- a/original_sdk/tests/test_client.py
+++ b/original_sdk/tests/test_client.py
@@ -4,7 +4,7 @@ import jwt
 import pytest
 from dotenv import load_dotenv
 
-from original_sdk import OriginalClient, Environment
+from original_sdk import Environment, OriginalClient
 
 load_dotenv()
 

--- a/original_sdk/types/environment.py
+++ b/original_sdk/types/environment.py
@@ -1,0 +1,16 @@
+from enum import Enum
+from typing import Union
+
+
+class Environment(Enum):
+    Development = "development"
+    Production = "production"
+
+
+def get_environment(env_input: Union[str, Environment]) -> Environment:
+    if isinstance(env_input, Environment):
+        return env_input
+    try:
+        return Environment(env_input.lower())
+    except ValueError:
+        raise ValueError(f"Invalid environment: {env_input}")


### PR DESCRIPTION
## Why
- Development apps should use the new api-dev.getoriginal.com URL

### How
- Provide an env option and enum to pass the environment
- Update readme and tests

### How Has This Been Tested?
- `make test`
- via local original-python-demo

### Checklist

Closes [ORI-1881]