### PR TITLE
fix: Inconsistent naming of params and incorrect example in readme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
     hooks:
       - id: lint
         name: lint
-        entry: make lint
+        entry: make lint-fix
         language: system
         types_or: [python, pyi]

--- a/README.md
+++ b/README.md
@@ -168,13 +168,17 @@ collection = client.get_collection('221137489875')
 The transfer methods exposed by the sdk are used to transfer assets from one user to another wallet.
 
 ```python
+
+# prepare the transfer params
+transfer_params = {
+    "asset_uid": asset_uid,
+    "from_user_uid": user_uid,
+    "to_address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+}
+
 # create a transfer of an asset, by passing in transfer details
 # returns the uid of the newly created transfer
-transfer_uid = client.create_transfer(
-  asset_uid = asset_uid,
-  from_user_uid = user_uid,
-  to_address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
-)
+transfer_uid = client.create_transfer(**transfer_params)
 
 # gets a transfer by uid, will throw a 404 Not Found error if the transfer does not exist
 transfer = client.get_transfer(transfer_uid)
@@ -189,12 +193,16 @@ transfers = client.get_transfers_by_user_uid(user_uid)
 The burn methods exposed by the sdk are used to burn assets from a user's wallet.
 
 ```python
+
+# prepare the burn params
+burn_params = {
+    "asset_uid": asset_uid,
+    "from_user_uid": user_uid,
+}
+
 # create a burn of an asset
 # returns the uid of the newly created burn
-burn_uid = client.create_burn(
-  asset_uid=asset_uid,
-  from_user_uid=user_uid,
-)
+burn_uid = client.create_burn(**burn_params)
 
 # gets a burn by uid, will throw a 404 Not Found error if the burn does not exist
 burn = client.get_burn(burn_uid)

--- a/original_sdk/async_client.py
+++ b/original_sdk/async_client.py
@@ -117,8 +117,8 @@ class OriginalAsyncClient(BaseOriginalClient, AsyncContextManager):
     async def create_user(self, email: str, client_id: str) -> OriginalResponse:
         return await self.post("user", data={"email": email, "client_id": client_id})
 
-    async def get_user(self, user_id: str) -> OriginalResponse:
-        return await self.get(f"user/{user_id}")
+    async def get_user(self, uid: str) -> OriginalResponse:
+        return await self.get(f"user/{uid}")
 
     async def get_user_by_email(self, email: str) -> OriginalResponse:
         return await self.get("user", params={"email": email})
@@ -132,32 +132,32 @@ class OriginalAsyncClient(BaseOriginalClient, AsyncContextManager):
     async def create_asset(self, **asset_data: Any) -> OriginalResponse:
         return await self.post("asset", data=asset_data)
 
-    async def edit_asset(self, asset_uid: str, **asset_data: Any) -> OriginalResponse:
-        return await self.put(f"asset/{asset_uid}", data=asset_data)
+    async def edit_asset(self, uid: str, **asset_data: Any) -> OriginalResponse:
+        return await self.put(f"asset/{uid}", data=asset_data)
 
-    async def get_asset(self, asset_uid: str) -> OriginalResponse:
-        return await self.get(f"asset/{asset_uid}")
+    async def get_asset(self, uid: str) -> OriginalResponse:
+        return await self.get(f"asset/{uid}")
 
-    async def get_assets_by_user_uid(self, app_user_uid: str) -> OriginalResponse:
-        return await self.get("asset", params={"user_uid": app_user_uid})
+    async def get_assets_by_user_uid(self, user_uid: str) -> OriginalResponse:
+        return await self.get("asset", params={"user_uid": user_uid})
 
     async def create_transfer(self, **transfer_data: Any) -> OriginalResponse:
         return await self.post("transfer", data=transfer_data)
 
-    async def get_transfer(self, transfer_uid: str) -> OriginalResponse:
-        return await self.get(f"transfer/{transfer_uid}")
+    async def get_transfer(self, uid: str) -> OriginalResponse:
+        return await self.get(f"transfer/{uid}")
 
-    async def get_transfers_by_user_uid(self, app_user_uid: str) -> OriginalResponse:
-        return await self.get("transfer", params={"user_uid": app_user_uid})
+    async def get_transfers_by_user_uid(self, user_uid: str) -> OriginalResponse:
+        return await self.get("transfer", params={"user_uid": user_uid})
 
     async def create_burn(self, **burn_data: Any) -> OriginalResponse:
         return await self.post("burn", data=burn_data)
 
-    async def get_burn(self, burn_uid: str) -> OriginalResponse:
-        return await self.get(f"burn/{burn_uid}")
+    async def get_burn(self, uid: str) -> OriginalResponse:
+        return await self.get(f"burn/{uid}")
 
-    async def get_burns_by_user_uid(self, app_user_uid: str) -> OriginalResponse:
-        return await self.get("burn", params={"user_uid": app_user_uid})
+    async def get_burns_by_user_uid(self, user_uid: str) -> OriginalResponse:
+        return await self.get("burn", params={"user_uid": user_uid})
 
     async def get_deposit(self, user_uid: str) -> OriginalResponse:
         return await self.get("deposit", params={"user_uid": user_uid})

--- a/original_sdk/base/client.py
+++ b/original_sdk/base/client.py
@@ -159,12 +159,12 @@ class BaseOriginalClient(abc.ABC):
 
     @abc.abstractmethod
     def edit_asset(
-        self, asset_uid: str, **asset_data: Any
+        self, uid: str, **asset_data: Any
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
         Update an Original asset.
 
-        :param asset_uid: the asset uid
+        :param uid: the asset uid
         :param asset_data: the asset data
         :return:
         """
@@ -172,24 +172,24 @@ class BaseOriginalClient(abc.ABC):
 
     @abc.abstractmethod
     def get_asset(
-        self, asset_uid: str
+        self, uid: str
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
         Get an Original asset.
 
-        :param asset_uid: the asset uid
+        :param uid: the asset uid
         :return:
         """
         pass
 
     @abc.abstractmethod
     def get_assets_by_user_uid(
-        self, app_user_uid: str
+        self, user_uid: str
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
-        Get an Original asset by owner uid.
+        Get a list of Original assets by user uid.
 
-        :param app_user_uid: the app user uid
+        :param user_uid: the user uid
         :return:
         """
         pass
@@ -208,24 +208,24 @@ class BaseOriginalClient(abc.ABC):
 
     @abc.abstractmethod
     def get_transfer(
-        self, transfer_uid: str
+        self, uid: str
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
         Get an Original transfer.
 
-        :param transfer_uid: the transfer uid
+        :param uid: the transfer uid
         :return:
         """
         pass
 
     @abc.abstractmethod
     def get_transfers_by_user_uid(
-        self, app_user_uid: str
+        self, user_uid: str
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
-        Get an Original transfer by user uid.
+        Get a list of Original transfers by user uid.
 
-        :param app_user_uid: the app user uid
+        :param user_uid: the user uid
         :return:
         """
         pass
@@ -244,24 +244,24 @@ class BaseOriginalClient(abc.ABC):
 
     @abc.abstractmethod
     def get_burn(
-        self, burn_uid: str
+        self, uid: str
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
         Get an Original burn.
 
-        :param burn_uid: the burn uid
+        :param uid: the burn uid
         :return:
         """
         pass
 
     @abc.abstractmethod
     def get_burns_by_user_uid(
-        self, app_user_uid: str
+        self, user_uid: str
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
-        Get an Original burn by user uid.
+        Get a list of Original burns by user uid.
 
-        :param app_user_uid: the app user uid
+        :param user_uid: the app user uid
         :return:
         """
         pass
@@ -273,7 +273,7 @@ class BaseOriginalClient(abc.ABC):
         """
         Get an Original deposit by user uid.
 
-        :param app_user_uid: the app user uid
+        :param user_uid: the user uid
         :return:
         """
         pass

--- a/original_sdk/client.py
+++ b/original_sdk/client.py
@@ -112,8 +112,8 @@ class OriginalClient(BaseOriginalClient):
     def create_user(self, email: str, client_id: str) -> OriginalResponse:
         return self.post("user", data={"email": email, "client_id": client_id})
 
-    def get_user(self, user_id: str) -> OriginalResponse:
-        return self.get(f"user/{user_id}")
+    def get_user(self, uid: str) -> OriginalResponse:
+        return self.get(f"user/{uid}")
 
     def get_user_by_email(self, email: str) -> OriginalResponse:
         return self.get("user", params={"email": email})
@@ -127,8 +127,8 @@ class OriginalClient(BaseOriginalClient):
     def create_asset(self, **asset_data: Any) -> OriginalResponse:
         return self.post("asset", data=asset_data)
 
-    def edit_asset(self, asset_uid: str, **asset_data: Any) -> OriginalResponse:
-        return self.put(f"asset/{asset_uid}", data=asset_data)
+    def edit_asset(self, uid: str, **asset_data: Any) -> OriginalResponse:
+        return self.put(f"asset/{uid}", data=asset_data)
 
     def get_asset(self, uid: str) -> OriginalResponse:
         return self.get(f"asset/{uid}")


### PR DESCRIPTION
## Why
- We are using inconsistent naming of params
- Readme is showing an incorrect example

### How
- Make the params that are referring to a pk use uid
- params that are to be used in a query `?user_uid=xxx` can be named as user_uid
- Fix example to what we are currently using

### How Has This Been Tested?
- Locally

### Checklist
