### PR TITLE
fix: Update Readme with error details. Return a reasonable error message for client side errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ class ValidationError(OriginalError): ...
 
 All errors inherit from an `OriginalError` class where you can access the standard properties from the `Exception` class as well as the following:
 
-```typescript
-export enum OriginalErrorCode {
-  clientError = 'client_error',
-  serverError = 'server_error',
-  validationError = 'validation_error',
-}
+```python
+class OriginalErrorCode(Enum):
+    client_error = "client_error"
+    server_error = "server_error"
+    validation_error = "validation_error"
+    
 
 class OriginalError(Exception):
     def __init__(self, message, status, data, code):

--- a/original_sdk/async_client.py
+++ b/original_sdk/async_client.py
@@ -8,6 +8,7 @@ from .__pkg__ import __version__
 from .base.client import BaseOriginalClient
 from .types.exceptions import ClientError
 from .types.original_response import OriginalResponse
+from .utils import get_default_error_message
 
 
 def get_user_agent() -> str:
@@ -51,7 +52,8 @@ class OriginalAsyncClient(BaseOriginalClient, AsyncContextManager):
             return json_response, headers, status
         except (json.JSONDecodeError, aiohttp.ContentTypeError):
             text = await response.text()
-            raise ClientError("Invalid JSON received", response.status, text)
+            message = get_default_error_message(response.status) or text
+            raise ClientError(message=message, status=response.status, data=message)
 
     async def _parse_response(
         self, response: aiohttp.ClientResponse

--- a/original_sdk/client.py
+++ b/original_sdk/client.py
@@ -8,6 +8,7 @@ from original_sdk.types.exceptions import ClientError
 from .__pkg__ import __version__
 from .base.client import BaseOriginalClient
 from .types.original_response import OriginalResponse
+from .utils import get_default_error_message
 
 
 def get_user_agent() -> str:
@@ -49,8 +50,9 @@ class OriginalClient(BaseOriginalClient):
             status = response.status_code
             return json_response, headers, status
         except ValueError:
+            message = get_default_error_message(response.status_code) or response.text
             raise ClientError(
-                "Invalid JSON received", response.status_code, response.text
+                message=message, status=response.status_code, data=message
             )
 
     def _parse_response(self, response: requests.Response) -> OriginalResponse:

--- a/original_sdk/tests/unit/test_async_client.py
+++ b/original_sdk/tests/unit/test_async_client.py
@@ -54,14 +54,14 @@ async def test_get_response_details_non_json(async_client):
         )
     )
     mock_response.text = MagicMock(return_value=asyncio.Future())
-    mock_response.text.return_value.set_result("Invalid JSON received")
+    mock_response.text.return_value.set_result("Bad Request")
 
     with pytest.raises(ClientError) as exc_info:
         await async_client._get_response_details(mock_response)
 
-    assert "Invalid JSON received" in str(exc_info.value)
+    assert "Bad Request" in str(exc_info.value)
     assert exc_info.value.status == 400
-    assert "Invalid JSON received" in exc_info.value.message
+    assert "Bad Request" in exc_info.value.message
 
 
 @pytest.mark.asyncio

--- a/original_sdk/tests/unit/test_utils.py
+++ b/original_sdk/tests/unit/test_utils.py
@@ -1,6 +1,8 @@
 import string
 
-from original_sdk.utils import get_random_string
+import pytest
+
+from original_sdk.utils import get_default_error_message, get_random_string
 
 
 def test_random_string_length():
@@ -29,3 +31,21 @@ def test_random_string_uniqueness():
         "Two consecutive calls to get_random_string produced the same output, "
         "which is highly unlikely for a properly functioning random generator"
     )
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_message",
+    [
+        (200, "OK"),
+        (404, "Not Found"),
+        (500, "Internal Server Error"),
+        (418, "I'm a Teapot"),
+    ],
+)
+def test_get_default_error_message_valid_codes(status_code, expected_message):
+    assert get_default_error_message(status_code) == expected_message
+
+
+def test_get_default_error_message_unknown_code():
+    invalid_status_code = 999
+    assert get_default_error_message(invalid_status_code) == "Unknown Error"

--- a/original_sdk/utils.py
+++ b/original_sdk/utils.py
@@ -1,8 +1,17 @@
 import random
 import string
+from http import HTTPStatus
 
 
 def get_random_string(length: int) -> str:
     characters = string.ascii_letters + string.digits
     random_string = "".join(random.choice(characters) for i in range(length))
     return random_string
+
+
+def get_default_error_message(status_code: int) -> str:
+    try:
+        status = HTTPStatus(status_code)
+        return status.phrase
+    except ValueError:
+        return "Unknown Error"


### PR DESCRIPTION
## Why
- We need to mention more error details in the readme
- We need to handle client side errors better if they do not come from our server

### How
- Update readme so its in line with JS
- Return a reasonable error from the default http error status if we cannot parse the response (either because its a 404 and doesn't reach our server or from some other network error)

### How Has This Been Tested?
- Locally

### Checklist
Before:
![Screenshot 2024-02-26 at 13 46 41](https://github.com/getoriginal/original-python/assets/10096212/ed1aa307-4644-43a2-b144-e84238032a54)

After:
![Screenshot 2024-02-26 at 13 48 51](https://github.com/getoriginal/original-python/assets/10096212/aa129798-30fd-4bfc-b293-68932bd60bf8)

