### PR TITLE
fix(ORI-2185): allow user params to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
     - [Get deposit details for a user](#get-deposit-details-by-user-uid)
   - [Collection](#collection)
     - [Get a collection by UID](#get-a-collection-by-collection-uid)
+  - [Handling Errors](#handling-errors)
 
 
 ## ✨ Getting started

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The user methods exposed by the sdk are used to create and retrieve users from t
 
 ```python
 # Returns a response object. Access the user's UID through the `data` attribute.
-create_response = client.create_user(email='YOUR_EMAIL', client_id='YOUR_CLIENT_ID')
+create_response = client.create_user()
 new_user_uid = create_response['data']['uid']
 # Sample create_response:
 {
@@ -103,6 +103,12 @@ new_user_uid = create_response['data']['uid']
         "uid": "175324281338"
     }
 }
+
+# You can also pass in a client_id and/or email for your external reference.
+# The client ID and/or email supplied must be unique per app
+create_response = client.create_user(email='YOUR_EMAIL', client_id='YOUR_CLIENT_ID')
+new_user_uid = create_response['data']['uid']
+# ...
 ```
 
 ### Get a user by UID

--- a/original_sdk/async_client.py
+++ b/original_sdk/async_client.py
@@ -1,6 +1,15 @@
 import json
 from types import TracebackType
-from typing import Any, AsyncContextManager, Callable, Dict, Optional, Tuple, Type
+from typing import (
+    Any,
+    AsyncContextManager,
+    Callable,
+    Dict,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import aiohttp
 
@@ -116,7 +125,9 @@ class OriginalAsyncClient(BaseOriginalClient, AsyncContextManager):
     ) -> OriginalResponse:
         return await self._make_request(self.session.patch, relative_url, params, data)
 
-    async def create_user(self, email: str, client_id: str) -> OriginalResponse:
+    async def create_user(
+        self, email: Union[None, str], client_id: Union[None, str]
+    ) -> OriginalResponse:
         return await self.post("user", data={"email": email, "client_id": client_id})
 
     async def get_user(self, uid: str) -> OriginalResponse:

--- a/original_sdk/async_client.py
+++ b/original_sdk/async_client.py
@@ -126,7 +126,7 @@ class OriginalAsyncClient(BaseOriginalClient, AsyncContextManager):
         return await self._make_request(self.session.patch, relative_url, params, data)
 
     async def create_user(
-        self, email: Union[None, str], client_id: Union[None, str]
+        self, email: Union[None, str] = None, client_id: Union[None, str] = None
     ) -> OriginalResponse:
         return await self.post("user", data={"email": email, "client_id": client_id})
 

--- a/original_sdk/base/client.py
+++ b/original_sdk/base/client.py
@@ -90,7 +90,7 @@ class BaseOriginalClient(abc.ABC):
 
     @abc.abstractmethod
     def create_user(
-        self, email: Union[None, str], client_id: Union[None, str]
+        self, email: Union[None, str] = None, client_id: Union[None, str] = None
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
         Create an Original user.

--- a/original_sdk/base/client.py
+++ b/original_sdk/base/client.py
@@ -90,7 +90,7 @@ class BaseOriginalClient(abc.ABC):
 
     @abc.abstractmethod
     def create_user(
-        self, email: str, client_id: str
+        self, email: Union[None, str], client_id: Union[None, str]
     ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
         """
         Create an Original user.

--- a/original_sdk/client.py
+++ b/original_sdk/client.py
@@ -112,7 +112,7 @@ class OriginalClient(BaseOriginalClient):
         return self._make_request(self.session.patch, relative_url, params, data)
 
     def create_user(
-        self, email: Union[None, str], client_id: Union[None, str]
+        self, email: Union[None, str] = None, client_id: Union[None, str] = None
     ) -> OriginalResponse:
         return self.post("user", data={"email": email, "client_id": client_id})
 

--- a/original_sdk/client.py
+++ b/original_sdk/client.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple, Union
 
 import requests
 
@@ -111,7 +111,9 @@ class OriginalClient(BaseOriginalClient):
     ) -> OriginalResponse:
         return self._make_request(self.session.patch, relative_url, params, data)
 
-    def create_user(self, email: str, client_id: str) -> OriginalResponse:
+    def create_user(
+        self, email: Union[None, str], client_id: Union[None, str]
+    ) -> OriginalResponse:
         return self.post("user", data={"email": email, "client_id": client_id})
 
     def get_user(self, uid: str) -> OriginalResponse:

--- a/original_sdk/tests/e2e/test_async_client_e2e.py
+++ b/original_sdk/tests/e2e/test_async_client_e2e.py
@@ -23,11 +23,15 @@ TEST_RETRY_COUNTER = 30
 
 
 class TestAsyncClientE2E:
-    async def test_create_user(self, async_client: OriginalAsyncClient):
+    async def test_create_user_with_params(self, async_client: OriginalAsyncClient):
         client_id = get_random_string(8)
         response = await async_client.create_user(
             email=f"{client_id}@test.com", client_id=client_id
         )
+        assert response["data"]["uid"] is not None
+
+    async def test_create_user_with_no_params(self, async_client: OriginalAsyncClient):
+        response = await async_client.create_user()
         assert response["data"]["uid"] is not None
 
     async def test_error_message(self, client: OriginalAsyncClient):

--- a/original_sdk/tests/e2e/test_client_e2e.py
+++ b/original_sdk/tests/e2e/test_client_e2e.py
@@ -22,11 +22,15 @@ TEST_RETRY_COUNTER = 30
 
 
 class TestClientE2E:
-    def test_create_user(self, client: OriginalClient):
+    def test_create_user_with_params(self, client: OriginalClient):
         client_id = get_random_string(8)
         response = client.create_user(
             email=f"{client_id}@test.com", client_id=client_id
         )
+        assert response["data"]["uid"] is not None
+
+    def test_create_user_with_no_params(self, client: OriginalClient):
+        response = client.create_user()
         assert response["data"]["uid"] is not None
 
     def test_error_message(self, client: OriginalClient):


### PR DESCRIPTION
## Why
- We should allow the user params, client_id and email to be optional when creating a user

### How
- Add optional markers
- Update comments/doc strings
- Add extra e2e test

### How Has This Been Tested?
- Locally via demo

### Checklist
