### PR TITLE
fix(ORI-2192): e2e tests for optional client_id in asset

### DIFF
--- a/original_sdk/tests/e2e/test_async_client_e2e.py
+++ b/original_sdk/tests/e2e/test_async_client_e2e.py
@@ -104,6 +104,28 @@ class TestAsyncClientE2E:
         response = await async_client.create_asset(**request_data)
         assert response["data"]["uid"] is not None
 
+    async def test_create_asset_with_no_client_id(
+        self, async_client: OriginalAsyncClient
+    ):
+        asset_name = get_random_string(8)
+        asset_data = {
+            "name": asset_name,
+            "unique_name": True,
+            "image_url": "https://example.com/image.png",
+            "store_image_on_ipfs": False,
+            "attributes": [
+                {"trait_type": "Eyes", "value": "Green"},
+                {"trait_type": "Hair", "value": "Black"},
+            ],
+        }
+        request_data = {
+            "data": asset_data,
+            "user_uid": TEST_APP_USER_UID,
+            "collection_uid": TEST_APP_COLLECTION_UID,
+        }
+        response = await async_client.create_asset(**request_data)
+        assert response["data"]["uid"] is not None
+
     async def test_edit_asset(self, async_client: OriginalAsyncClient):
         asset_name = get_random_string(8)
         asset_data = {

--- a/original_sdk/tests/e2e/test_client_e2e.py
+++ b/original_sdk/tests/e2e/test_client_e2e.py
@@ -97,6 +97,26 @@ class TestClientE2E:
         response = client.create_asset(**request_data)
         assert response["data"]["uid"] is not None
 
+    def test_create_asset_with_no_client_id(self, client: OriginalClient):
+        asset_name = get_random_string(8)
+        asset_data = {
+            "name": asset_name,
+            "unique_name": True,
+            "image_url": "https://example.com/image.png",
+            "store_image_on_ipfs": False,
+            "attributes": [
+                {"trait_type": "Eyes", "value": "Green"},
+                {"trait_type": "Hair", "value": "Black"},
+            ],
+        }
+        request_data = {
+            "data": asset_data,
+            "user_uid": TEST_APP_USER_UID,
+            "collection_uid": TEST_APP_COLLECTION_UID,
+        }
+        response = client.create_asset(**request_data)
+        assert response["data"]["uid"] is not None
+
     def test_edit_asset(self, client: OriginalClient):
         asset_name = get_random_string(8)
         asset_data = {


### PR DESCRIPTION
## Why
- Client ID is now optional in the asset, need to add tests for it

### How
- Added e2e tests for client and async client with no client_id

### How Has This Been Tested?
- Locally

### Checklist
