### PR TITLE
feat(ori-1752): add reward methods to sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,9 @@ jobs:
           TEST_TRANSFER_TO_USER_UID: ${{secrets.TEST_TRANSFER_TO_USER_UID}}
           TEST_TRANSFER_UID: ${{secrets.TEST_TRANSFER_UID}}
           TEST_BURN_UID: ${{secrets.TEST_BURN_UID}}
+          TEST_APP_REWARD_UID: ${{secrets.TEST_APP_REWARD_UID}}
+          TEST_ALLOCATION_UID: ${{secrets.TEST_ALLOCATION_UID}}
+          TEST_CLAIM_UID: ${{secrets.TEST_CLAIM_UID}}
+          TEST_CLAIM_TO_ADDRESS: ${{secrets.TEST_CLAIM_TO_ADDRESS}}
           PYTHONPATH: ${{ github.workspace }}
         run: make test

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@
     - [Get deposit details for a user](#get-deposit-details-by-user-uid)
   - [Collection](#collection)
     - [Get a collection by UID](#get-a-collection-by-collection-uid)
+  - [Allocation](#allocation)
+    - [Create a new allocation](#create-a-new-allocation)
+    - [Get an allocation by UID](#get-an-allocation-by-allocation-uid)
+    - [Get allocations by user UID](#get-allocations-by-user-uid)
+  - [Claim](#claim)
+    - [Create a new claim](#create-a-new-claim)
+    - [Get a claim by UID](#get-a-claim-by-claim-uid)
+    - [Get claims by user UID](#get-claims-by-user-uid)
+  - [Reward](#reward)
+    - [Get a reward by UID)](#get-a-reward-by-reward-uid)
   - [Handling Errors](#handling-errors)
 
 
@@ -538,6 +548,172 @@ collection_details = collection_response['data']
 }
 ```
 
+## Allocation
+
+The allocation methods exposed by the sdk are used to create and retrieve allocations from the Original API.
+
+### Create a new allocation
+```python
+
+# Prepare the allocation parameters
+allocation_params = {
+    "amount": 123.123,
+    "nonce": "nonce1",
+    "user_uid": "483581848722",
+    "reward_uid": "708469717542",
+}
+
+# Create an allocation
+allocation_response = client.create_allocation(**allocation_params)
+allocation_uid = allocation_response['data']['uid']
+# Sample allocation_response:
+{
+    "success": True,
+    "data": {
+        "uid": "365684656925",
+    }
+}
+```
+
+### Get an allocation by allocation UID
+```python
+
+# Get an allocation by UID, will throw a 404 Not Found error if the allocation does not exist
+allocation_response = client.get_allocation("365684656925")
+allocation_details = allocation_response['data']
+# Sample allocation_response:
+{
+    "success": True,
+    "data": {
+        "uid": "365684656925",
+        "status": "done",
+        "reward_uid": "reward_uid",
+        "to_user_uid": "754566475542",
+        "amount": 123.123,
+        "nonce": "nonce1",
+        "created_at": "2024-02-16T11:33:19.577827Z"
+    }
+}
+```
+
+### Get allocations by user UID
+```python
+# Get allocations by user UID
+allocations_response = client.get_allocations_by_user_uid("483581848722")
+allocations_list = allocations_response['data']
+# Sample allocations_response:
+{
+    "success": True,
+    "data": [
+        {
+            "uid": "365684656925",
+            "status": "done",
+            "reward_uid": "reward_uid",
+            "to_user_uid": "754566475542",
+            "amount": 123.123,
+            "nonce": "nonce1",
+            "created_at": "2024-02-16T11:33:19.577827Z"
+        }
+        # Additional allocations would be listed here
+    ]
+}
+```
+
+## Claim
+
+The claim methods exposed by the sdk are used to create and retrieve claims from the Original API.
+
+### Create a new claim
+```python
+
+# Prepare the claim parameters
+claim_params = {
+    "from_user_uid": "483581848722",
+    "reward_uid": "708469717542",
+    "to_address": '0x4881ab2f73c48a54b907a8b697b270f490768e6d'
+}
+
+# Create a claim
+claim_response = client.create_claim(**claim_params)
+claim_uid = claim_response['data']['uid']
+# Sample claim_response:
+{
+    "success": True,
+    "data": {
+        "uid": "365684656925",
+    }
+}
+```
+
+### Get a claim by claim UID
+```python
+
+# Get a claim by UID, will throw a 404 Not Found error if the claim does not exist
+claim_response = client.get_claim("365684656925")
+claim_details = claim_response['data']
+# Sample claim_response:
+{
+    "success": True,
+    "data": {
+        "uid": "365684656925",
+        "status": "done",
+        "reward_uid": "708469717542",
+        "from_user_uid": "754566475542",
+        "to_address": "0x4881ab2f73c48a54b907a8b697b270f490768e6d",
+        "amount": 123.123,
+        "created_at": "2024-02-16T11:33:19.577827Z"
+    }
+}
+```
+
+### Get claims by user UID
+```python
+# Get claims by user UID
+claims_response = client.get_claims_by_user_uid("483581848722")
+claims_list = claims_response['data']
+# Sample claims_response:
+{
+    "success": True,
+    "data": [
+        {
+            "uid": "365684656925",
+            "status": "done",
+            "reward_uid": "708469717542",
+            "from_user_uid": "754566475542",
+            "to_address": "0x4881ab2f73c48a54b907a8b697b270f490768e6d",
+            "amount": 123.123,
+            "created_at": "2024-02-16T11:33:19.577827Z"
+        }
+        # Additional claims would be listed here
+    ]
+}
+```
+
+## Reward
+
+The reward methods exposed by the sdk are used to retrieve reward details from the Original API.
+
+### Get a reward by reward UID
+```python
+# Get a reward by UID, will throw a 404 Not Found error if the reward does not exist
+reward_response = client.get_reward('221137489875')
+reward_details = reward_response['data']
+# Sample reward_response:
+{
+    "success": True,
+    "data": {
+        "uid": "151854912345",
+        "name": "Test SDK Reward 1",
+        "status": "deployed",
+        "token_type": "ERC20",
+        "token_name": "TestnetORI",
+        "created_at": "2024-02-13T10:45:56.952745Z",
+        "contract_address": "0x124a6755ee787153bb6228463d5dc3a02890a7db",
+        "description": "Description of the reward",
+        "explorer_url": "https://mumbai.polygonscan.com/address/0x124a6755ee787153bb6228463d5dc3a02890a7db"
+    }
+}
+```
 
 ### Handling Errors
 

--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ reward_details = reward_response['data']
         "token_name": "TestnetORI",
         "created_at": "2024-02-13T10:45:56.952745Z",
         "contract_address": "0x124a6755ee787153bb6228463d5dc3a02890a7db",
+        "withdraw_receiver": "0x4881ab2f73c48a54b907a8b697b270f490768e6d",
         "description": "Description of the reward",
         "explorer_url": "https://mumbai.polygonscan.com/address/0x124a6755ee787153bb6228463d5dc3a02890a7db"
     }

--- a/original_sdk/async_client.py
+++ b/original_sdk/async_client.py
@@ -175,6 +175,27 @@ class OriginalAsyncClient(BaseOriginalClient, AsyncContextManager):
     async def get_deposit(self, user_uid: str) -> OriginalResponse:
         return await self.get("deposit", params={"user_uid": user_uid})
 
+    async def get_reward(self, reward_uid: str) -> OriginalResponse:
+        return await self.get(f"reward/{reward_uid}")
+
+    async def create_allocation(self, **allocation_data: Any) -> OriginalResponse:
+        return await self.post("reward/allocate", data=allocation_data)
+
+    async def get_allocation(self, allocation_uid: str) -> OriginalResponse:
+        return await self.get(f"reward/allocate/{allocation_uid}")
+
+    async def get_allocations_by_user_uid(self, user_uid: str) -> OriginalResponse:
+        return await self.get("reward/allocate", params={"user_uid": user_uid})
+
+    async def create_claim(self, **claim_data: Any) -> OriginalResponse:
+        return await self.post("reward/claim", data=claim_data)
+
+    async def get_claim(self, claim_uid: str) -> OriginalResponse:
+        return await self.get(f"reward/claim/{claim_uid}")
+
+    async def get_claims_by_user_uid(self, user_uid: str) -> OriginalResponse:
+        return await self.get("reward/claim", params={"user_uid": user_uid})
+
     async def close(self) -> None:
         await self.session.close()
 

--- a/original_sdk/async_client.py
+++ b/original_sdk/async_client.py
@@ -175,14 +175,14 @@ class OriginalAsyncClient(BaseOriginalClient, AsyncContextManager):
     async def get_deposit(self, user_uid: str) -> OriginalResponse:
         return await self.get("deposit", params={"user_uid": user_uid})
 
-    async def get_reward(self, reward_uid: str) -> OriginalResponse:
-        return await self.get(f"reward/{reward_uid}")
+    async def get_reward(self, uid: str) -> OriginalResponse:
+        return await self.get(f"reward/{uid}")
 
     async def create_allocation(self, **allocation_data: Any) -> OriginalResponse:
         return await self.post("reward/allocate", data=allocation_data)
 
-    async def get_allocation(self, allocation_uid: str) -> OriginalResponse:
-        return await self.get(f"reward/allocate/{allocation_uid}")
+    async def get_allocation(self, uid: str) -> OriginalResponse:
+        return await self.get(f"reward/allocate/{uid}")
 
     async def get_allocations_by_user_uid(self, user_uid: str) -> OriginalResponse:
         return await self.get("reward/allocate", params={"user_uid": user_uid})
@@ -190,8 +190,8 @@ class OriginalAsyncClient(BaseOriginalClient, AsyncContextManager):
     async def create_claim(self, **claim_data: Any) -> OriginalResponse:
         return await self.post("reward/claim", data=claim_data)
 
-    async def get_claim(self, claim_uid: str) -> OriginalResponse:
-        return await self.get(f"reward/claim/{claim_uid}")
+    async def get_claim(self, uid: str) -> OriginalResponse:
+        return await self.get(f"reward/claim/{uid}")
 
     async def get_claims_by_user_uid(self, user_uid: str) -> OriginalResponse:
         return await self.get("reward/claim", params={"user_uid": user_uid})

--- a/original_sdk/base/client.py
+++ b/original_sdk/base/client.py
@@ -277,3 +277,87 @@ class BaseOriginalClient(abc.ABC):
         :return:
         """
         pass
+
+    @abc.abstractmethod
+    def get_reward(
+        self, uid: str
+    ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
+        """
+        Get an Original reward.
+
+        :param uid: the reward uid
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_allocation(
+        self, **allocation_data: Any
+    ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
+        """
+        Create an Original allocation.
+
+        :param allocation_data: the allocation data
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_allocation(
+        self, uid: str
+    ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
+        """
+        Get an Original allocation.
+
+        :param uid: the allocation uid
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_allocations_by_user_uid(
+        self, user_uid: str
+    ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
+        """
+        Get a list of Original allocations by user uid.
+
+        :param user_uid: the app user uid
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_claim(
+        self, **claim_data: Any
+    ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
+        """
+        Create an Original claim.
+
+        :param claim_data: the claim data
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_claim(
+        self, uid: str
+    ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
+        """
+        Get an Original claim.
+
+        :param uid: the claim uid
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_claims_by_user_uid(
+        self, user_uid: str
+    ) -> Union[OriginalResponse, Awaitable[OriginalResponse]]:
+        """
+        Get a list of Original claims by user uid.
+
+        :param user_uid: the app user uid
+        :return:
+        """
+        pass

--- a/original_sdk/client.py
+++ b/original_sdk/client.py
@@ -161,14 +161,14 @@ class OriginalClient(BaseOriginalClient):
     def get_deposit(self, user_uid: str) -> OriginalResponse:
         return self.get("deposit", params={"user_uid": user_uid})
 
-    def get_reward(self, reward_uid: str) -> OriginalResponse:
-        return self.get(f"reward/{reward_uid}")
+    def get_reward(self, uid: str) -> OriginalResponse:
+        return self.get(f"reward/{uid}")
 
     def create_allocation(self, **allocation_data: Any) -> OriginalResponse:
         return self.post("reward/allocate", data=allocation_data)
 
-    def get_allocation(self, allocation_uid: str) -> OriginalResponse:
-        return self.get(f"reward/allocate/{allocation_uid}")
+    def get_allocation(self, uid: str) -> OriginalResponse:
+        return self.get(f"reward/allocate/{uid}")
 
     def get_allocations_by_user_uid(self, user_uid: str) -> OriginalResponse:
         return self.get("reward/allocate", params={"user_uid": user_uid})
@@ -176,8 +176,8 @@ class OriginalClient(BaseOriginalClient):
     def create_claim(self, **claim_data: Any) -> OriginalResponse:
         return self.post("reward/claim", data=claim_data)
 
-    def get_claim(self, claim_uid: str) -> OriginalResponse:
-        return self.get(f"reward/claim/{claim_uid}")
+    def get_claim(self, uid: str) -> OriginalResponse:
+        return self.get(f"reward/claim/{uid}")
 
     def get_claims_by_user_uid(self, user_uid: str) -> OriginalResponse:
         return self.get("reward/claim", params={"user_uid": user_uid})

--- a/original_sdk/client.py
+++ b/original_sdk/client.py
@@ -160,3 +160,24 @@ class OriginalClient(BaseOriginalClient):
 
     def get_deposit(self, user_uid: str) -> OriginalResponse:
         return self.get("deposit", params={"user_uid": user_uid})
+
+    def get_reward(self, reward_uid: str) -> OriginalResponse:
+        return self.get(f"reward/{reward_uid}")
+
+    def create_allocation(self, **allocation_data: Any) -> OriginalResponse:
+        return self.post("reward/allocate", data=allocation_data)
+
+    def get_allocation(self, allocation_uid: str) -> OriginalResponse:
+        return self.get(f"reward/allocate/{allocation_uid}")
+
+    def get_allocations_by_user_uid(self, user_uid: str) -> OriginalResponse:
+        return self.get("reward/allocate", params={"user_uid": user_uid})
+
+    def create_claim(self, **claim_data: Any) -> OriginalResponse:
+        return self.post("reward/claim", data=claim_data)
+
+    def get_claim(self, claim_uid: str) -> OriginalResponse:
+        return self.get(f"reward/claim/{claim_uid}")
+
+    def get_claims_by_user_uid(self, user_uid: str) -> OriginalResponse:
+        return self.get("reward/claim", params={"user_uid": user_uid})

--- a/original_sdk/tests/e2e/test_async_client_e2e.py
+++ b/original_sdk/tests/e2e/test_async_client_e2e.py
@@ -17,6 +17,10 @@ TEST_APP_COLLECTION_UID = os.getenv("TEST_APP_COLLECTION_UID")
 TEST_ASSET_UID = os.getenv("TEST_ASSET_UID")
 TEST_TRANSFER_TO_WALLET_ADDRESS = os.getenv("TEST_TRANSFER_TO_WALLET_ADDRESS")
 TEST_TRANSFER_TO_USER_UID = os.getenv("TEST_TRANSFER_TO_USER_UID")
+TEST_APP_REWARD_UID = os.getenv("TEST_APP_REWARD_UID")
+TEST_ALLOCATION_UID = os.getenv("TEST_ALLOCATION_UID")
+TEST_CLAIM_UID = os.getenv("TEST_CLAIM_UID")
+TEST_CLAIM_TO_ADDRESS = os.getenv("TEST_CLAIM_TO_ADDRESS")
 TEST_ACCEPTANCE_CHAIN_ID = 80001
 TEST_ACCEPTANCE_NETWORK = "Mumbai"
 TEST_RETRY_COUNTER = 30
@@ -200,6 +204,81 @@ class TestAsyncClientE2E:
         assert response["data"]["chain_id"] == TEST_ACCEPTANCE_CHAIN_ID
         assert response["data"]["network"] == TEST_ACCEPTANCE_NETWORK
 
+    async def test_get_reward(self, async_client: OriginalAsyncClient):
+        response = await async_client.get_reward(TEST_APP_REWARD_UID)
+        assert response["data"]["uid"] == TEST_APP_REWARD_UID
+
+    async def test_get_reward_not_found_throws_404(
+        self, async_client: OriginalAsyncClient
+    ):
+        try:
+            await async_client.get_reward("not_found")
+        except ClientError as e:
+            assert e.status == 404
+
+    async def test_create_allocation(self, async_client: OriginalAsyncClient):
+        allocation_data = {
+            "amount": 0.001,
+            "nonce": get_random_string(8),
+            "reward_uid": TEST_APP_REWARD_UID,
+            "to_user_uid": TEST_APP_USER_UID,
+        }
+        response = await async_client.create_allocation(**allocation_data)
+        assert response["data"]["uid"] is not None
+
+    async def test_get_allocation(self, async_client: OriginalAsyncClient):
+        response = await async_client.get_allocation(TEST_ALLOCATION_UID)
+        assert response["data"]["uid"] == TEST_ALLOCATION_UID
+
+    async def test_get_allocation_not_found_throws_404(
+        self, async_client: OriginalAsyncClient
+    ):
+        try:
+            await async_client.get_allocation("not_found")
+        except ClientError as e:
+            assert e.status == 404
+
+    async def test_get_allocations_by_user_uid(self, async_client: OriginalAsyncClient):
+        response = await async_client.get_allocations_by_user_uid(TEST_APP_USER_UID)
+        assert isinstance(response["data"], list)
+
+    async def test_get_allocations_by_user_uid_with_no_results(
+        self, async_client: OriginalAsyncClient
+    ):
+        response = await async_client.get_allocations_by_user_uid("no_results")
+        assert response["data"] == []
+
+    async def test_create_claim(self, async_client: OriginalAsyncClient):
+        claim_data = {
+            "reward_uid": TEST_APP_REWARD_UID,
+            "from_user_uid": TEST_APP_USER_UID,
+            "to_address": TEST_CLAIM_TO_ADDRESS,
+        }
+        response = await async_client.create_claim(**claim_data)
+        assert response["data"]["uid"] is not None
+
+    async def test_get_claim(self, async_client: OriginalAsyncClient):
+        response = await async_client.get_claim(TEST_CLAIM_UID)
+        assert response["data"]["uid"] == TEST_CLAIM_UID
+
+    async def test_get_claim_not_found_throws_404(
+        self, async_client: OriginalAsyncClient
+    ):
+        try:
+            await async_client.get_claim("not_found")
+        except ClientError as e:
+            assert e.status == 404
+
+    async def test_get_claims_by_user_uid(self, async_client: OriginalAsyncClient):
+        response = await async_client.get_claims_by_user_uid(TEST_APP_USER_UID)
+        assert isinstance(response["data"], list)
+
+    async def test_get_claims_by_user_uid_with_no_results(
+        self, async_client: OriginalAsyncClient
+    ):
+        response = await async_client.get_claims_by_user_uid("no_results")
+        assert response["data"] == []
+
     async def test_full_create_transfer_burn_asset_flow(
         self, async_client: OriginalAsyncClient
     ):
@@ -289,3 +368,47 @@ class TestAsyncClientE2E:
         final_asset = await async_client.get_asset(asset_uid)
         assert final_asset["success"] is True
         assert final_asset["data"]["is_burned"] is True
+
+    async def test_full_allocate_claim_flow(self, async_client: OriginalAsyncClient):
+        allocation_data = {
+            "amount": 0.001,
+            "nonce": get_random_string(8),
+            "reward_uid": TEST_APP_REWARD_UID,
+            "to_user_uid": TEST_APP_USER_UID,
+        }
+        response = await async_client.create_allocation(**allocation_data)
+        allocation_uid = response["data"]["uid"]
+        is_allocating = True
+        retries = 0
+
+        while is_allocating is True and retries < TEST_RETRY_COUNTER:
+            response = await async_client.get_allocation(allocation_uid)
+            is_allocating = response["data"]["status"] != "done"
+            if is_allocating:
+                await asyncio.sleep(15)
+            retries += 1
+
+        allocation_response = await async_client.get_allocation(allocation_uid)
+        assert (
+            allocation_response["success"] is True
+        ), f"Allocation {allocation_uid} is not done."
+
+        claim_data = {
+            "reward_uid": TEST_APP_REWARD_UID,
+            "from_user_uid": TEST_APP_USER_UID,
+            "to_address": TEST_CLAIM_TO_ADDRESS,
+        }
+
+        response = await async_client.create_claim(**claim_data)
+        claim_uid = response["data"]["uid"]
+        is_claiming = True
+
+        while is_claiming is True and retries < TEST_RETRY_COUNTER:
+            response = await async_client.get_claim(claim_uid)
+            is_claiming = response["data"]["status"] != "done"
+            if is_claiming:
+                await asyncio.sleep(15)
+            retries += 1
+
+        claim_response = await async_client.get_claim(claim_uid)
+        assert claim_response["success"] is True, f"Claim {claim_uid} is not done."

--- a/original_sdk/tests/e2e/test_client_e2e.py
+++ b/original_sdk/tests/e2e/test_client_e2e.py
@@ -16,6 +16,10 @@ TEST_APP_COLLECTION_UID = os.getenv("TEST_APP_COLLECTION_UID")
 TEST_ASSET_UID = os.getenv("TEST_ASSET_UID")
 TEST_TRANSFER_TO_WALLET_ADDRESS = os.getenv("TEST_TRANSFER_TO_WALLET_ADDRESS")
 TEST_TRANSFER_TO_USER_UID = os.getenv("TEST_TRANSFER_TO_USER_UID")
+TEST_APP_REWARD_UID = os.getenv("TEST_APP_REWARD_UID")
+TEST_ALLOCATION_UID = os.getenv("TEST_ALLOCATION_UID")
+TEST_CLAIM_UID = os.getenv("TEST_CLAIM_UID")
+TEST_CLAIM_TO_ADDRESS = os.getenv("TEST_CLAIM_TO_ADDRESS")
 TEST_ACCEPTANCE_CHAIN_ID = 80001
 TEST_ACCEPTANCE_NETWORK = "Mumbai"
 TEST_RETRY_COUNTER = 30
@@ -187,6 +191,71 @@ class TestClientE2E:
         assert response["data"]["chain_id"] == TEST_ACCEPTANCE_CHAIN_ID
         assert response["data"]["network"] == TEST_ACCEPTANCE_NETWORK
 
+    def test_get_reward(self, client: OriginalClient):
+        response = client.get_reward(TEST_APP_REWARD_UID)
+        assert response["data"]["uid"] == TEST_APP_REWARD_UID
+
+    def test_get_reward_not_found_throws_404(self, client: OriginalClient):
+        try:
+            client.get_reward("not_found")
+        except ClientError as e:
+            assert e.status == 404
+
+    def test_create_allocation(self, client: OriginalClient):
+        allocation_data = {
+            "amount": 0.001,
+            "nonce": get_random_string(8),
+            "reward_uid": TEST_APP_REWARD_UID,
+            "to_user_uid": TEST_APP_USER_UID,
+        }
+        response = client.create_allocation(**allocation_data)
+        assert response["data"]["uid"] is not None
+
+    def test_get_allocation(self, client: OriginalClient):
+        response = client.get_allocation(TEST_ALLOCATION_UID)
+        assert response["data"]["uid"] == TEST_ALLOCATION_UID
+
+    def test_get_allocation_not_found_throws_404(self, client: OriginalClient):
+        try:
+            client.get_allocation("not_found")
+        except ClientError as e:
+            assert e.status == 404
+
+    def test_get_allocations_by_user_uid(self, client: OriginalClient):
+        response = client.get_allocations_by_user_uid(TEST_APP_USER_UID)
+        assert isinstance(response["data"], list)
+
+    def test_get_allocations_by_user_uid_with_no_results(self, client: OriginalClient):
+        response = client.get_allocations_by_user_uid("no_results")
+        assert response["data"] == []
+
+    def test_create_claim(self, client: OriginalClient):
+        claim_data = {
+            "reward_uid": TEST_APP_REWARD_UID,
+            "from_user_uid": TEST_APP_USER_UID,
+            "to_address": TEST_CLAIM_TO_ADDRESS,
+        }
+        response = client.create_claim(**claim_data)
+        assert response["data"]["uid"] is not None
+
+    def test_get_claim(self, client: OriginalClient):
+        response = client.get_claim(TEST_CLAIM_UID)
+        assert response["data"]["uid"] == TEST_CLAIM_UID
+
+    def test_get_claim_not_found_throws_404(self, client: OriginalClient):
+        try:
+            client.get_claim("not_found")
+        except ClientError as e:
+            assert e.status == 404
+
+    def test_get_claims_by_user_uid(self, client: OriginalClient):
+        response = client.get_claims_by_user_uid(TEST_APP_USER_UID)
+        assert isinstance(response["data"], list)
+
+    def test_get_claims_by_user_uid_with_no_results(self, client: OriginalClient):
+        response = client.get_claims_by_user_uid("no_results")
+        assert response["data"] == []
+
     def test_full_create_transfer_burn_asset_flow(self, client: OriginalClient):
         asset_name = get_random_string(8)
         asset_data = {
@@ -279,3 +348,47 @@ class TestClientE2E:
         final_asset = client.get_asset(asset_uid)
         assert final_asset["success"] is True, f"Asset {asset_uid} is not burned."
         assert final_asset["data"]["is_burned"] is True
+
+    def test_full_allocate_claim_flow(self, client: OriginalClient):
+        allocation_data = {
+            "amount": 0.001,
+            "nonce": get_random_string(8),
+            "reward_uid": TEST_APP_REWARD_UID,
+            "to_user_uid": TEST_APP_USER_UID,
+        }
+        response = client.create_allocation(**allocation_data)
+        allocation_uid = response["data"]["uid"]
+        is_allocating = True
+        retries = 0
+
+        while is_allocating is True and retries < TEST_RETRY_COUNTER:
+            response = client.get_allocation(allocation_uid)
+            is_allocating = response["data"]["status"] != "done"
+            if is_allocating:
+                time.sleep(15)
+            retries += 1
+
+        allocation_response = client.get_allocation(allocation_uid)
+        assert (
+            allocation_response["success"] is True
+        ), f"Allocation {allocation_uid} is not done."
+
+        claim_data = {
+            "reward_uid": TEST_APP_REWARD_UID,
+            "from_user_uid": TEST_APP_USER_UID,
+            "to_address": TEST_CLAIM_TO_ADDRESS,
+        }
+
+        response = client.create_claim(**claim_data)
+        claim_uid = response["data"]["uid"]
+        is_claiming = True
+
+        while is_claiming is True and retries < TEST_RETRY_COUNTER:
+            response = client.get_claim(claim_uid)
+            is_claiming = response["data"]["status"] != "done"
+            if is_claiming:
+                time.sleep(15)
+            retries += 1
+
+        claim_response = client.get_claim(claim_uid)
+        assert claim_response["success"] is True, f"Claim {claim_uid} is not done."

--- a/original_sdk/tests/unit/base/test_client.py
+++ b/original_sdk/tests/unit/base/test_client.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Union
 
 import jwt
 import pytest
@@ -14,7 +14,9 @@ DEFAULT_API_VERSION = "v1"
 
 
 class MockClient(BaseOriginalClient):
-    def create_user(self, email: str, client_id: str):
+    def create_user(
+        self, email: Union[None, str] = None, client_id: Union[None, str] = None
+    ):
         pass
 
     def get_user(self, uid: str):
@@ -60,6 +62,27 @@ class MockClient(BaseOriginalClient):
         pass
 
     def get_deposit(self, user_uid: str):
+        pass
+
+    def get_reward(self, uid: str):
+        pass
+
+    def create_allocation(self, **allocation_data: Any):
+        pass
+
+    def get_allocation(self, uid: str):
+        pass
+
+    def get_allocations_by_user_uid(self, user_uid: str):
+        pass
+
+    def create_claim(self, **claim_data: Any):
+        pass
+
+    def get_claim(self, uid: str):
+        pass
+
+    def get_claims_by_user_uid(self, user_uid: str):
         pass
 
 


### PR DESCRIPTION
## Why
Update sdk to include new endpoints for the reward api
### How
- add reward methods (get)
- add allocation methods (post, get_by_uid, get_by_user_uid)
- add claim method (post, get_by_uid, get_by_user_uid)
### How Has This Been Tested?
e2e tests
