### PR TITLE
fix(ori-2365): fix release script ignoring pre-release versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
             // Getting the release version from the PR source branch
             // Source branch looks like this: release-1.0.0
-            const version = context.payload.pull_request.head.ref.split('-')[1]
+            const version = context.payload.pull_request.head.ref.split('-').slice(1).join('-');
             core.exportVariable('VERSION', version)
 
       - uses: actions/setup-python@v3


### PR DESCRIPTION
## Why
- If we had a version like v0.0.1-alpha.1, the version would still be v0.0.1, ignoring the pre-release version

### How
- Add support for the pre-release version

### How Has This Been Tested?
With metaplex python port

### Checklist
